### PR TITLE
Add tooltip functionality to Create and Save Annotation buttons

### DIFF
--- a/experiment_pages/create_experiment/summary_ui.py
+++ b/experiment_pages/create_experiment/summary_ui.py
@@ -8,6 +8,7 @@ from shared.scrollable_frame import ScrolledFrame
 from shared.experiment import Experiment
 from experiment_pages.experiment.experiment_menu_ui import ExperimentMenuUI
 from shared.password_utils import PasswordManager
+from shared.tooltip_utils import ToolTip
 
 class CreateExperimentButton(CTkButton):
     '''Button to save a new experiment.'''
@@ -67,7 +68,22 @@ class SummaryUI(MouserPage):# pylint: disable=undefined-variable
         self.input = experiment
         self.menu = menu_page
 
-        CreateExperimentButton(experiment, self, menu_page)
+        create_btn = CreateExperimentButton(experiment, self, menu_page)
+
+        ToolTip(create_btn, "Create and save the experiment")
+
+        save_annotation_button = CTkButton(
+            self,
+            text="Save annotation",
+            state="disabled",
+            width=15,
+            fg_color="#98FB98",
+            hover_color="#90EE90",
+            text_color="black"
+        )
+        save_annotation_button.place(relx=0.92, rely=0.15, anchor=CENTER)
+        ToolTip(save_annotation_button, "This will save annotations. (Disabled for now)")
+
 
         scroll_canvas = ScrolledFrame(self)
         scroll_canvas.place(relx=0.10, rely=0.25, relheight=0.7, relwidth=0.8)

--- a/experiment_pages/create_experiment/summary_ui.py
+++ b/experiment_pages/create_experiment/summary_ui.py
@@ -77,8 +77,8 @@ class SummaryUI(MouserPage):# pylint: disable=undefined-variable
             text="Save annotation",
             state="disabled",
             width=15,
-            fg_color="#98FB98",
-            hover_color="#90EE90",
+            fg_color="#289228",
+            hover_color="#6DDB6D",
             text_color="black"
         )
         save_annotation_button.place(relx=0.92, rely=0.15, anchor=CENTER)

--- a/shared/tooltip_utils.py
+++ b/shared/tooltip_utils.py
@@ -1,0 +1,63 @@
+from customtkinter import CTkLabel, CTkToplevel
+
+class ToolTip:
+    def __init__(self, widget, text):
+        self.widget = widget
+        self.text = text
+        self.tip_window = None
+        self.mouse_inside = False
+
+        # Bind events to track entry/exit
+        widget.bind("<Enter>", self.on_enter_widget)
+        widget.bind("<Leave>", self.on_leave_widget)
+
+    def on_enter_widget(self, event=None):
+        self.mouse_inside = True
+        self.show_tip()
+
+    def on_leave_widget(self, event=None):
+        self.mouse_inside = False
+        self.widget.after(100, self.check_mouse)
+
+    def on_enter_tip(self, event=None):
+        self.mouse_inside = True
+
+    def on_leave_tip(self, event=None):
+        self.mouse_inside = False
+        self.widget.after(100, self.check_mouse)
+
+    def check_mouse(self):
+        if not self.mouse_inside:
+            self.hide_tip()
+
+    def show_tip(self):
+        if self.tip_window or not self.text:
+            return
+
+        x = self.widget.winfo_rootx() + 25
+        y = self.widget.winfo_rooty() + 20
+
+        self.tip_window = tw = CTkToplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tw.wm_geometry(f"+{x}+{y}")
+
+        label = CTkLabel(
+            tw,
+            text=self.text,
+            justify="left",
+            bg_color="lightyellow",
+            text_color="black",
+            corner_radius=4,
+            padx=6,
+            pady=3
+        )
+        label.pack()
+
+        # Bind tooltip events
+        tw.bind("<Enter>", self.on_enter_tip)
+        tw.bind("<Leave>", self.on_leave_tip)
+
+    def hide_tip(self):
+        if self.tip_window:
+            self.tip_window.destroy()
+            self.tip_window = None


### PR DESCRIPTION
Add tooltip functionality to Create and Save Annotation buttons and screen-bound handling

- Implemented custom ToolTip class using CTkToplevel to show hover text.
- Ensured tooltips disappear correctly when mouse leaves both button and tooltip.
- Assigned descriptive tooltips to Create and Save Annotation buttons.

![Save Annotations button](https://github.com/user-attachments/assets/59734e53-e1ce-4457-abbe-67a440283252)

