### PR TITLE
Add update annotation functionality to services and UI

### DIFF
--- a/api_services/services.py
+++ b/api_services/services.py
@@ -45,3 +45,25 @@ def get_annotations(experiment_id):
     except Exception as e:
         return None, str(e)
 
+def update_annotation(annotation_id, new_text):
+    token = get_token()
+    headers = {"Authorization": f"Bearer {token}"}
+    
+    updated_annotation = {
+        "@id": annotation_id,
+        "body": {
+            "type": "TextualBody",
+            "value": new_text,
+            "format": "text/plain"
+        }
+    }
+
+    try:
+        response = requests.post(f"{RERUM_BASE}/update", json=updated_annotation, headers=headers)
+        
+        if response.status_code == 200:
+            return True, response.json()
+        else:
+            return False, response.text
+    except Exception as e:
+        return False, str(e)


### PR DESCRIPTION
Pull Request: Add Annotation Update Functionality

### Summary

This pull request introduces the feature to **update existing annotations** within the Mouser application. It leverages the ReRUM API and extends the existing annotation workflow (create and fetch) to support annotation modification.

---

### Changes Made

-  **Logic:**
  - Added `update_annotation(annotation_id, new_text)` in `services.py` to handle annotation updates via ReRUM
-  **UI:**
  - Integrated update functionality in `new_experiment_ui.py`
  - Created a new button and input fields to collect `annotation_id` and `new_text`
-  **Support:**
  - Ensured consistent JSON-LD structure
  - Added basic error handling for missing/invalid token and API failures
