### PR TITLE
Added Delete annotation button in Load Annotation pop up.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyo
 .DS_Store
 .venv/
+rerum_server_nodejs

--- a/api_services/services.py
+++ b/api_services/services.py
@@ -67,3 +67,30 @@ def update_annotation(annotation_id, new_text):
             return False, response.text
     except Exception as e:
         return False, str(e)
+
+def delete_annotations_by_experiment(experiment_id):
+    token = get_token()
+    headers = {"Authorization": f"Bearer {token}"}
+    query = {"target": experiment_id}
+    try:
+        # First, query annotations for the experiment_id
+        response = requests.post(f"{RERUM_BASE}/query", json=query, headers=headers)
+        if response.status_code != 200:
+            return False, f"Failed to query annotations: {response.text}"
+
+        annotations = response.json()
+        if not annotations:
+            return True, None 
+
+        # Delete each annotation
+        for annotation in annotations:
+            annotation_id = annotation.get("@id")
+            if not annotation_id:
+                continue
+            delete_response = requests.delete(f"{RERUM_BASE}/delete/{annotation_id}", headers=headers)
+            if delete_response.status_code not in (200, 204):
+                return False, f"Failed to delete annotation {annotation_id}: {delete_response.text}"
+
+        return True, None
+    except Exception as e:
+        return False, str(e)


### PR DESCRIPTION
**Description:**
This PR introduces a "Delete" button to the Load Annotation pop-up UI with the following behavior:

The "Delete" button is disabled by default.

It becomes enabled only when an annotation is successfully fetched.

It remains disabled if the annotation fetch fails or no annotation is selected.

**UI Changes:**

The Load Annotation dialog layout is updated to include the new "Delete" button.

Button placement is aligned with existing UI elements for consistent visual design.