### PR TITLE
Pull Request: Fix Annotation Deletion Not Persisting in MongoDB

### DIFF
--- a/api_services/services.py
+++ b/api_services/services.py
@@ -84,7 +84,8 @@ def delete_annotations_by_experiment(experiment_id):
 
         # Delete each annotation
         for annotation in annotations:
-            annotation_id = annotation.get("@id")
+            full_id = annotation['id']
+            annotation_id = full_id.split("/")[-1]
             if not annotation_id:
                 continue
             delete_response = requests.delete(f"{RERUM_BASE}/delete/{annotation_id}", headers=headers)


### PR DESCRIPTION
**Description:**
This PR updates the "Delete annotation" functionality to perform a soft delete instead of permanently removing the annotation from MongoDB.

**Changes Implemented:**

When a user clicks the "Delete annotation" button, the annotation is now marked as inactive instead of being deleted.

The frontend and backend logic have been updated accordingly:
- The UI shows a success message only after confirming the item is marked inactive.
- The backend GET endpoints now exclude inactive annotations from fetch results.
- MongoDB will still store the annotation for record-keeping or auditing purposes, but it will no longer be retrievable via the UI.

**User Experience Impact:**

- From the frontend perspective, deleted annotations will not appear when attempting to load them again.
- If the user tries to fetch an inactive annotation by ID, the frontend will display "No data found".